### PR TITLE
Fix string_to_string warnings

### DIFF
--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -94,7 +94,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     }
 
     public string? get_name_for_xkb_layout (string language, string? variant) {
-        debug (@"get_name_for_xkb_layout (%s, %s)".printf (language, variant));
+        debug ("get_name_for_xkb_layout (%s, %s)".printf (language, variant));
         Xml.Doc* doc = Xml.Parser.parse_file ("/usr/share/X11/xkb/rules/evdev.xml");
         if (doc == null) {
             critical ("'evdev.xml' not found or permissions incorrect\n");
@@ -121,7 +121,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
         if (res->type != Xml.XPath.ObjectType.NODESET || res->nodesetval == null) {
             delete res;
             delete doc;
-            //warning (@"No name for $language:$variant found in 'evdev.xml'");
+            warning ("No name for %s: %s found in 'evdev.xml'".printf (language, variant));
             return null;
         }
 

--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -22,7 +22,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     private GLib.Settings settings;
     private Gtk.Grid main_grid;
 
-    public class LayoutManager () {
+    public LayoutManager () {
         populate_layouts ();
     }
 
@@ -94,7 +94,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     }
 
     public string? get_name_for_xkb_layout (string language, string? variant) {
-        debug (@"get_name_for_xkb_layout ($language $variant)");
+        debug (@"get_name_for_xkb_layout (%s, %s)".printf (language, variant));
         Xml.Doc* doc = Xml.Parser.parse_file ("/usr/share/X11/xkb/rules/evdev.xml");
         if (doc == null) {
             critical ("'evdev.xml' not found or permissions incorrect\n");
@@ -121,7 +121,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
         if (res->type != Xml.XPath.ObjectType.NODESET || res->nodesetval == null) {
             delete res;
             delete doc;
-            warning (@"No name for $language:$variant found in 'evdev.xml'");
+            //warning (@"No name for $language:$variant found in 'evdev.xml'");
             return null;
         }
 

--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -94,7 +94,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     }
 
     public string? get_name_for_xkb_layout (string language, string? variant) {
-        debug ("get_name_for_xkb_layout (%s, %s)".printf (language, variant));
+        debug ("get_name_for_xkb_layout (%s, %s)", language, variant);
         Xml.Doc* doc = Xml.Parser.parse_file ("/usr/share/X11/xkb/rules/evdev.xml");
         if (doc == null) {
             critical ("'evdev.xml' not found or permissions incorrect\n");
@@ -121,7 +121,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
         if (res->type != Xml.XPath.ObjectType.NODESET || res->nodesetval == null) {
             delete res;
             delete doc;
-            warning ("No name for %s: %s found in 'evdev.xml'".printf (language, variant));
+            warning ("No name for %s: %s found in 'evdev.xml'", language, variant);
             return null;
         }
 


### PR DESCRIPTION
Fixes `string_to_string` warnings. Correct the formatting of `warning ()` and `debug ()` functions.