### PR TITLE
build: fix install path for wingpanel indicator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,18 +5,22 @@ project(
 )
 
 i18n = import('i18n')
+gnome = import('gnome')
 gettext_name = meson.project_name() + '-indicator'
+
+prefix = get_option('prefix')
+libdir = join_paths(prefix, get_option('libdir'))
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
 
-wingpanel_dep = dependency('wingpanel-2.0')
-
-gnome = import('gnome')
 gresource = gnome.compile_resources(
     'gresource',
     join_paths('data', 'keyboard.gresource.xml'),
     source_dir: 'data'
 )
+
+wingpanel_dep = dependency('wingpanel-2.0')
+wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
 
 shared_module(
     meson.project_name(),
@@ -34,7 +38,7 @@ shared_module(
         wingpanel_dep
     ],
     install: true,
-    install_dir : wingpanel_dep.get_pkgconfig_variable('indicatorsdir')
+    install_dir : wingpanel_indicatorsdir
 )
 
 subdir('po')


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this wingpanel_dep.get_pkgconfig_variable will return a
path from within wingpanel's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.