### PR TITLE
Indicator: show in greeter

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -104,11 +104,9 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
     }
 }
 
-public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
-    // Temporal workarround for Greeter crash
-    if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION)
-        return null;
+public Wingpanel.Indicator get_indicator (Module module) {
     debug ("Activating Keyboard Indicator");
     var indicator = new Keyboard.Indicator ();
+
     return indicator;
 }


### PR DESCRIPTION
Fixes https://github.com/elementary/wingpanel-indicator-keyboard/issues/5 https://github.com/elementary/greeter/issues/128

---

Opened as a draft because there's some sort of crash being reported. From the reports it seems to be some dbus service not running in the greeter session, which we could fix inside the greeter. 