### PR TITLE
Enable in greeter

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -103,9 +103,6 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
 }
 
 public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
-    // Temporal workarround for Greeter crash
-    if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION)
-        return null;
     debug ("Activating Keyboard Indicator");
     var indicator = new Keyboard.Indicator ();
     return indicator;


### PR DESCRIPTION
I'm not seeing a crash in the greeter on the daily 6.0 builds. We'll need to check whether this works OK on 5.1 too to decide if it breaks compatibility or not.