### PR TITLE
Honor show all sources setting

### DIFF
--- a/data/keyboard.appdata.xml.in
+++ b/data/keyboard.appdata.xml.in
@@ -7,6 +7,12 @@
   <summary>The keyboard indicator</summary>
   <icon type="stock">preferences-desktop-keyboard</icon>
   <releases>
+    <release version="2.3.0" date="2020-04-01" urgency="medium">
+      <description>
+        <p>Add setting to show keyboard layout even when only one available</p>
+        <p>Updated translations</p>
+      </description>
+    </release>
     <release version="2.2.1" date="2020-04-01" urgency="medium">
       <description>
         <p>Updated translations</p>

--- a/data/keyboard.gschema.xml
+++ b/data/keyboard.gschema.xml
@@ -12,7 +12,7 @@
       <description>Shows numlock key's status in the wingpanel</description>
     </key>
     <key name="always-show-layout" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Always show keyboard layout</summary>
       <description>Shows the current keyboard layout even if there is only one available</description>
     </key>

--- a/data/keyboard.gschema.xml
+++ b/data/keyboard.gschema.xml
@@ -11,5 +11,10 @@
       <summary>Numlock Status</summary>
       <description>Shows numlock key's status in the wingpanel</description>
     </key>
+    <key name="always-show-layout" type="b">
+      <default>true</default>
+      <summary>Always show keyboard layout</summary>
+      <description>Shows the current keyboard layout even if there is only one available</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -83,6 +83,7 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
             });
 
             layouts = new Keyboard.Widgets.LayoutManager ();
+            settings.bind ("always-show-layout", layouts, "always-show", SettingsBindFlags.DEFAULT);
             layouts.updated.connect (() => {
                 layouts_icon.label = layouts.get_current (true);
                 layouts_revealer.reveal_child = layouts.has_layouts ();

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -25,6 +25,8 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
     private Gtk.Revealer numlock_revealer;
     private Gtk.Revealer capslock_revealer;
     private Keyboard.Widgets.LayoutManager layouts;
+    private Keyboard.Widgets.KeyboardIcon layouts_icon;
+    private Gtk.Revealer layouts_revealer;
 
     public Indicator (Wingpanel.IndicatorManager.ServerType server_type) {
         Object (
@@ -49,9 +51,9 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
             };
             capslock_revealer.add (capslock_icon);
 
-            var layouts_icon = new Keyboard.Widgets.KeyboardIcon ();
+            layouts_icon = new Keyboard.Widgets.KeyboardIcon ();
 
-            var layouts_revealer = new Gtk.Revealer () {
+            layouts_revealer = new Gtk.Revealer () {
                 transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT
             };
             layouts_revealer.add (layouts_icon);
@@ -85,9 +87,6 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
             layouts = new Keyboard.Widgets.LayoutManager ();
             settings.bind ("always-show-layout", layouts, "always-show", SettingsBindFlags.DEFAULT);
             layouts.updated.connect (() => {
-                layouts_icon.label = layouts.get_current (true);
-                layouts_revealer.reveal_child = layouts.has_layouts ();
-
                 update_visibiity ();
             });
 
@@ -98,22 +97,25 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
     }
 
     private void update_visibiity () {
+        layouts_icon.label = layouts.get_current (true);
+
+        layouts_revealer.reveal_child = layouts.has_multiple_layouts () || settings.get_boolean ("always-show-layout");
         numlock_revealer.reveal_child = keymap.get_num_lock_state () && settings.get_boolean ("numlock");
         capslock_revealer.reveal_child = keymap.get_caps_lock_state () && settings.get_boolean ("capslock");
 
-        if (numlock_revealer.reveal_child && (layouts.has_layouts () || capslock_revealer.reveal_child)) {
+        if (numlock_revealer.reveal_child && (layouts_revealer.reveal_child || capslock_revealer.reveal_child)) {
             numlock_revealer.margin_end = 6;
         } else {
             numlock_revealer.margin_end = 0;
         }
 
-        if (capslock_revealer.reveal_child && layouts.has_layouts ()) {
+        if (capslock_revealer.reveal_child && layouts_revealer.reveal_child) {
             capslock_revealer.margin_end = 6;
         } else {
             capslock_revealer.margin_end = 0;
         }
 
-        visible = layouts.has_layouts () || numlock_revealer.reveal_child || capslock_revealer.reveal_child;
+        visible = layouts_revealer.reveal_child || numlock_revealer.reveal_child || capslock_revealer.reveal_child;
     }
 
     public override Gtk.Widget? get_widget () {

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -85,7 +85,6 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
             });
 
             layouts = new Keyboard.Widgets.LayoutManager ();
-            settings.bind ("always-show-layout", layouts, "always-show", SettingsBindFlags.DEFAULT);
             layouts.updated.connect (() => {
                 update_visibiity ();
             });

--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -48,6 +48,10 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
             updated ();
         });
 
+        settings.changed["show-all-sources"].connect_after (() => {
+            updated ();
+        });
+
         show_all ();
     }
 
@@ -198,6 +202,6 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     }
 
     public bool has_layouts () {
-        return main_grid.get_children ().length () > 1;
+        return main_grid.get_children ().length () > 1 || settings.get_boolean ("show-all-sources");
     }
 }

--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -24,6 +24,8 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     private GLib.Settings settings;
     private Gtk.Grid main_grid;
 
+    public bool always_show { get; set; }
+
     public LayoutManager () {
         populate_layouts ();
     }
@@ -51,6 +53,10 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
         });
 
         settings.changed["show-all-sources"].connect_after (() => {
+            updated ();
+        });
+
+        notify["always-show"].connect (() => {
             updated ();
         });
 
@@ -204,6 +210,6 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     }
 
     public bool has_layouts () {
-        return main_grid.get_children ().length () > 1 || settings.get_boolean ("show-all-sources");
+        return always_show || main_grid.get_children ().length () > 1;
     }
 }

--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -24,8 +24,6 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
     private GLib.Settings settings;
     private Gtk.Grid main_grid;
 
-    public bool always_show { get; set; }
-
     public LayoutManager () {
         populate_layouts ();
     }
@@ -53,10 +51,6 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
         });
 
         settings.changed["show-all-sources"].connect_after (() => {
-            updated ();
-        });
-
-        notify["always-show"].connect (() => {
             updated ();
         });
 
@@ -209,7 +203,7 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
         });
     }
 
-    public bool has_layouts () {
-        return always_show || main_grid.get_children ().length () > 1;
+    public bool has_multiple_layouts () {
+        return main_grid.get_children ().length () > 1;
     }
 }

--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -50,10 +50,6 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
             updated ();
         });
 
-        settings.changed["show-all-sources"].connect_after (() => {
-            updated ();
-        });
-
         show_all ();
     }
 


### PR DESCRIPTION
Shows the input source even if there is only one if the corresponding setting is true.  This allows convenient access to keyboard settings and layout if desired.

Note this does not fix the issue with not showing ibus input methods, which will be tackled in another PR.