### PR TITLE
Release 2.3.0

### DIFF
--- a/data/keyboard.appdata.xml.in
+++ b/data/keyboard.appdata.xml.in
@@ -7,9 +7,9 @@
   <summary>The keyboard indicator</summary>
   <icon type="stock">preferences-desktop-keyboard</icon>
   <releases>
-    <release version="2.3.0" date="2020-04-01" urgency="medium">
+    <release version="2.3.0" date="2020-12-23" urgency="medium">
       <description>
-        <p>Add setting to show keyboard layout even when only one available</p>
+        <p>Optionally show CapsLock and Numlock indicators</p>
         <p>Updated translations</p>
       </description>
     </release>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'keyboard',
     'vala', 'c',
-    version: '2.2.1'
+    version: '2.3.0'
 )
 
 i18n = import('i18n')


### PR DESCRIPTION
The version of switchboard-plug-keyboard in Hera has controls for these settings, but it does not have one for always showing with one layout, so exclude that for now from the changelog.

Otherwise, this works as expected on Hera