### PR TITLE
Don't construct invisible widgets

### DIFF
--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -57,6 +57,12 @@ public class Keyboard.Widgets.LayoutManager : Gtk.ScrolledWindow {
         var source_list = settings.get_value ("sources");
         LayoutButton layout_button = null;
         var iter = source_list.iterator ();
+
+        // Don't construct widgets if we're not going to show the indicator anyway
+        if (iter.n_children () <= 1) {
+            return;
+        }
+
         int i = 0;
         string manager_type;
         string source;


### PR DESCRIPTION
No point continuing in this method to construct widgets that won't ever be visible because we only show the layout icons when there are 2+ layouts.

Edit: On second thoughts, this doesn't work that well now that we have the numlock and capslock thing. I'll rethink slightly.