### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,8 @@ xkb_base = xkbconf.get_pkgconfig_variable('xkb_base')
 
 conf_data = configuration_data()
 conf_data.set('XKB_BASE', xkb_base)
+conf_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf_data.set('GETTEXT_PACKAGE', meson.project_name() + '-indicator')
 config_file = configure_file (
     input: 'src/Config.vala.in',
     output: 'Config.vala',

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,3 +1,5 @@
 namespace Constants {
     public const string XKB_BASE = "@XKB_BASE@";
+    public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    public const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -29,6 +29,9 @@ public class Keyboard.Indicator : Wingpanel.Indicator {
     private Gtk.Revealer layouts_revealer;
 
     public Indicator (Wingpanel.IndicatorManager.ServerType server_type) {
+        GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+
         Object (
             code_name: Wingpanel.Indicator.KEYBOARD,
             server_type: server_type


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)