### PR TITLE
Remove `xkb::us::eng`

### DIFF
--- a/src/LayoutsManager.vala
+++ b/src/LayoutsManager.vala
@@ -273,8 +273,6 @@ public class Keyboard.Widgets.LayoutManager : Gtk.Box {
                                   string source) {
         switch (manager) {
             case XKB_MANAGER_TYPE:
-                //This engine just echo keys so this results in the current xkb keyboard layout set by Gala being used
-                bus.set_global_engine ("xkb:us::eng");
                 break;
             case IBUS_MANAGER_TYPE:
                 bus.set_global_engine (source);


### PR DESCRIPTION
An attempt to fix #108

So I encountered #108 (again) after reinstalling elementary OS, so I dug into gsettings value and found out that an additional `('ibus', 'xkb:us::eng')` layout was added, this is the only place we use it and I guess it somehow adds it. Not sure how to test this on the new system.