### PR TITLE
PopoverWidget: use ListBoxes

### DIFF
--- a/src/PopoverWidget.vala
+++ b/src/PopoverWidget.vala
@@ -34,8 +34,8 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
 #else
     private List<weak IBus.EngineDesc> engines;
 #endif
-    private Gtk.Box xkb_box;
-    private Gtk.Box ibus_box;
+    private Gtk.ListBox xkb_box;
+    private Gtk.ListBox ibus_box;
     private Gtk.Revealer ibus_box_revealer;
     private Gtk.Revealer ibus_header_revealer;
     private Granite.SwitchModelButton ibus_header;
@@ -54,10 +54,7 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
 
         var xkb_header = new Granite.HeaderLabel (_("Keyboard Layout"));
 
-        xkb_box = new Gtk.Box (VERTICAL, 0) {
-            hexpand = true,
-            vexpand = true
-        };
+        xkb_box = new Gtk.ListBox ();
 
         ibus_header = new Granite.SwitchModelButton (_("Input Method")) {
             active = true
@@ -77,10 +74,7 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
             child = ibus_header_box
         };
 
-        ibus_box = new Gtk.Box (VERTICAL, 0) {
-            hexpand = true,
-            vexpand = true
-        };
+        ibus_box = new Gtk.ListBox ();
 
         ibus_box_revealer = new Gtk.Revealer () {
             child = ibus_box
@@ -176,13 +170,13 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
     }
 
     private void populate_layouts () {
-        xkb_box.get_children ().foreach ((child) => {
-            child.destroy ();
-        });
+        while (xkb_box.get_row_at_index (0) != null) {
+            xkb_box.remove (xkb_box.get_row_at_index (0));
+        }
 
-        ibus_box.get_children ().foreach ((child) => {
-            child.destroy ();
-        });
+        while (ibus_box.get_row_at_index (0) != null) {
+            ibus_box.remove (ibus_box.get_row_at_index (0));
+        }
 
         ibus_header_revealer.reveal_child = false;
         ibus_box_revealer.reveal_child = false;
@@ -285,7 +279,7 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
             i++;
         }
 
-        if (ibus_box.get_children ().length () > 0) {
+        if (ibus_box.get_row_at_index (0) != null) {
             ibus_header_revealer.reveal_child = true;
             ibus_box_revealer.reveal_child = ibus_header.active;
         }
@@ -385,19 +379,19 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
         string xkb_label = _("Default keyboard layout");  //Fallback
         string ibus_label = "";
 
-        xkb_box.get_children ().foreach ((child) => {
-            var row = (LayoutButton)child;
-            if (row.active) {
-                xkb_label = _("Keyboard Layout: %s").printf (row.description);
+        for (int i = 0; xkb_box.get_row_at_index (i) != null; i++) {
+            var layout_button = (LayoutButton) xkb_box.get_row_at_index (i).get_child ();
+            if (layout_button.active) {
+                xkb_label = _("Keyboard Layout: %s").printf (layout_button.description);
             }
-        });
+        }
 
-        ibus_box.get_children ().foreach ((child) => {
-            var row = (LayoutButton)child;
-            if (row.active) {
-                ibus_label = _("Input Method: %s").printf (row.description);
+        for (int i = 0; ibus_box.get_row_at_index (i) != null; i++) {
+            var layout_button = (LayoutButton) ibus_box.get_row_at_index (i).get_child ();
+            if (layout_button.active) {
+                ibus_label = _("Input Method: %s").printf (layout_button.description);
             }
-        });
+        }
 
         if (ibus_label != "") {
             return "%s\n%s".printf (ibus_label, xkb_label);
@@ -421,11 +415,11 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
     }
 
     private void set_active_layout_to_xkb () {
-        foreach (Gtk.Widget child in xkb_box.get_children ()) {
-            var button = (LayoutButton) child;
-            if (button.active) {
-                settings.set_value ("current", button.index);
-                set_ibus_engine (XKB_MANAGER_TYPE, button.source); //Make sure ibus input method not active.
+        for (int i = 0; xkb_box.get_row_at_index (i) != null; i++) {
+            var layout_button = (LayoutButton) xkb_box.get_row_at_index (i).get_child ();
+            if (layout_button.active) {
+                settings.set_value ("current", layout_button.index);
+                set_ibus_engine (XKB_MANAGER_TYPE, layout_button.source); //Make sure ibus input method not active.
             }
         }
     }
@@ -437,35 +431,36 @@ public class Keyboard.Widgets.PopoverWidget : Gtk.Box {
         updated ();
     }
 
-    private void set_layout_active_in_box (Gtk.Box layout_box, uint index, bool clear) {
-        var children = layout_box.get_children ();
-        LayoutButton? previously_active_button = null;
+    private void set_layout_active_in_box (Gtk.ListBox layout_box, uint index, bool clear) {
         bool found = false;
-        /* Do not assume what order the buttons will be put in box */
-        children.@foreach ((widget) => {
-            var button = (LayoutButton) widget;
+        LayoutButton? previously_active_button = null;
 
-            if (button.index == index) {
+        /* Do not assume what order the buttons will be put in box */
+        for (int i = 0; layout_box.get_row_at_index (i) != null; i++) {
+            var layout_button = (LayoutButton) layout_box.get_row_at_index (i).get_child ();
+            if (layout_button.index == index) {
                 found = true;
-                button.active = true;
-                current_language_code = button.language_code;
-                current_layout_variant = button.layout_variant;
+                layout_button.active = true;
+                current_language_code = layout_button.language_code;
+                current_layout_variant = layout_button.layout_variant;
+
                 if (bus.is_connected ()) {
-                    set_ibus_engine (button.manager_type, button.source);
+                    set_ibus_engine (layout_button.manager_type, layout_button.source);
                 }
-            } else if (button.active) {
-                previously_active_button = (owned) button;
+            } else if (layout_button.active) {
+                previously_active_button = (owned) layout_button;
             }
-        });
+        }
 
         if (found) {
             if (previously_active_button != null) {
                 previously_active_button.active = false;
             }
         } else if (clear) {
-            children.@foreach ((widget) => {
-                ((LayoutButton) widget).active = false;
-            });
+            for (int i = 0; layout_box.get_row_at_index (i) != null; i++) {
+                var layout_button = (LayoutButton) layout_box.get_row_at_index (i).get_child ();
+                layout_button.active = false;
+            }
         }
     }
 


### PR DESCRIPTION
We can't use `get_children` in GTK4, so this gets rid of most of those instances and helps move towards eventually being able to manage layouts in a listmodel